### PR TITLE
Modify the way we retrive build dates

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 
+// Format a date to the string value expected by https://android-review.googlesource.com
 function formatDate(date: Date): string {
   const pad = (num: number) => num.toString().padStart(2, '0');
 
@@ -16,6 +17,38 @@ function formatDate(date: Date): string {
   return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}`;
 }
 
+// Parse a date string from a maven-metadata.xml (e.g. 20250201002912)
+function parseMetadataDate(dateStr: string): Date | null {
+  if (dateStr.length !== 14 || isNaN(Number(dateStr))) {
+    return null; // Invalid input
+  }
+
+  const year = parseInt(dateStr.substring(0, 4), 10);
+  const month = parseInt(dateStr.substring(4, 6), 10) - 1;
+  const day = parseInt(dateStr.substring(6, 8), 10);
+  const hour = parseInt(dateStr.substring(8, 10), 10);
+  const minute = parseInt(dateStr.substring(10, 12), 10);
+  const second = parseInt(dateStr.substring(12, 14), 10);
+
+  // Create Date object in UTC
+  return new Date(Date.UTC(year, month, day, hour, minute, second));
+}
+
+// Fetch and parse the date of a given build
+async function getBuildDate(buildId: string): Promise<Date | null> {
+  // Get build maven-metadata.xml from any of its artifacts
+  const buildResponse = await fetch(`https://androidx.dev/snapshots/builds/${buildId}/artifacts/repository/androidx/activity/activity/maven-metadata.xml`);
+  const buildText = await buildResponse.text()
+  // Use regex to extract the date instead of parsing the xml text
+  const buildDateMatch = buildText.match(/<lastUpdated>(.*?)<\/lastUpdated>/);
+  if (buildDateMatch) {
+    const dateStr = buildDateMatch[1]
+    const date = parseMetadataDate(dateStr)
+    return date
+  } else {
+    return null
+  }
+}
 
 export default function Home() {
 
@@ -28,19 +61,16 @@ export default function Home() {
     // Clear any previous result url
     setResultsUrl("")
     try {
-      // Get build epochs
-      const goodBuildResponse = await fetch(`https://androidx.dev/snapshots/builds/${buildStart}/artifacts/logs/STARTED`);
-      const goodBuildEpoch = await goodBuildResponse.text()
-      const badBuildResponse = await fetch(`https://androidx.dev/snapshots/builds/${buildEnd}/artifacts/logs/STARTED`);
-      const badBuildEpoch = await badBuildResponse.text()
-      console.log("Start epoch", goodBuildEpoch)
-      console.log("End epoch", badBuildEpoch)
-      if (goodBuildEpoch == "" || badBuildEpoch == "") return;
-      // Create build dates
-      const startDate = new Date(parseInt(goodBuildEpoch) * 1000);
-      const endDate = new Date(parseInt(badBuildEpoch) * 1000);
+      // Get build dates
+      const [startDate, endDate] = await Promise.all([
+        getBuildDate(buildStart),
+        getBuildDate(buildEnd),
+      ])
+
+      if (!startDate || !endDate) return;
       console.log("Start date", startDate)
       console.log("End date", endDate)
+
       // Format dates to use a date accepted by Gerrit
       const startDateFormatted = formatDate(startDate)
       const endDateFormatted = formatDate(endDate)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +22,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Since the date from the STARTED url is no longer available, we are replacing it with the `lastUpdated` value from any artifact's maven-metadata.xml.

NOTE: We can’t get dates dates from https://ci.android.com/builds/ because its CORS policy.